### PR TITLE
Add CLAUDE.md, publish workflow, and dev tooling

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,23 @@
+name: Preview Build
+
+on:
+  push:
+    branches-ignore:
+      - pages
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Build site
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
+          PAGES_REPO_NWO: ${{ github.repository }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "markdown.styles": ["markdown-light.css"]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md
+
+## Project Overview
+
+Personal technical blog hosted on GitHub Pages.
+
+## Tech Stack
+
+- **Static site generator**: Jekyll with GitHub Pages (`github-pages` gem)
+- **Theme**: [So Simple](https://github.com/mmistakes/so-simple-theme) v3.2.0 (remote theme)
+- **Math rendering**: MathJax (tex-mml-chtml combo, AMS tags)
+- **Markdown engine**: kramdown with Rouge syntax highlighting
+- **Pre-commit**: pre-commit hooks (large file check, trailing whitespace, line endings, etc.)
+
+## Project Structure
+
+```
+_posts/          # Blog posts (Markdown with YAML front matter)
+_layouts/        # HTML layout templates
+_includes/       # Reusable HTML partials
+_data/           # Site data (navigation, authors, text)
+_sass/           # Stylesheets
+_site/           # Generated site (do not edit, gitignored)
+assets/          # CSS and JS assets
+images/          # Post images
+_config.yml      # Jekyll site configuration
+```
+
+## Branching & Publishing
+
+- **`pages`** — 发布分支，GitHub Pages 从此分支部署，推送到此分支会触发部署
+- **其他分支** — 工作分支，推送只触发构建验证（CI），不会触发部署
+- 发布：在工作分支上完成修改后，运行 `bash publish.sh` 合并到 `pages` 并推送
+
+## Common Commands
+
+```bash
+# Local development server (port 4001)
+bash run.sh
+
+# Publish current branch to pages (triggers deployment)
+bash publish.sh
+
+# Install dependencies
+bundle install
+```
+
+## Writing Posts
+
+- Posts go in `_posts/` with filename format: `YYYY-MM-DD-Title.md`
+- Posts use `layout: post` by default (configured in `_config.yml` front matter defaults)
+- Math: use `$...$` for inline and `$$...$$` for display math (MathJax enabled)
+- Images: place in `images/`, reference as `/images/filename.png`
+- Code blocks: use fenced code blocks with language identifier; Rouge provides syntax highlighting with line numbers

--- a/markdown-light.css
+++ b/markdown-light.css
@@ -1,0 +1,4 @@
+body {
+  background-color: #ffffff;
+  color: #1e1e1e;
+}

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+# Publish the current branch to the pages branch (triggers GitHub Pages deployment).
+# Usage: bash publish.sh
+
+CURRENT_BRANCH=$(git symbolic-ref --short HEAD)
+PUBLISH_BRANCH="pages"
+
+if [ "$CURRENT_BRANCH" = "$PUBLISH_BRANCH" ]; then
+  echo "Already on $PUBLISH_BRANCH. Switch to a working branch first."
+  exit 1
+fi
+
+echo "Publishing $CURRENT_BRANCH -> $PUBLISH_BRANCH"
+
+git checkout "$PUBLISH_BRANCH"
+git merge "$CURRENT_BRANCH" --no-edit
+git push origin "$PUBLISH_BRANCH"
+git checkout "$CURRENT_BRANCH"
+
+echo "Done. Site will be deployed from $PUBLISH_BRANCH."


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: project guide for Claude Code sessions
- **Preview CI** (`.github/workflows/preview.yml`): non-pages branches only trigger build validation, not deployment
- **publish.sh**: one-command script to merge current branch into `pages` and push
- **Markdown light preview** (`.vscode/settings.json` + `markdown-light.css`): VS Code markdown preview uses light theme

## Test plan
- [ ] `bash run.sh` still works for local preview
- [ ] Push to a non-pages branch triggers the preview CI workflow
- [ ] `bash publish.sh` merges to pages and triggers deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)